### PR TITLE
Pass -dead_stip -dead_strip_dylibs -bind_at_load on macOS

### DIFF
--- a/ui/papersapling.pro
+++ b/ui/papersapling.pro
@@ -62,6 +62,9 @@ FORMS += \
 INCLUDEPATH += $$PWD/qtlib/src
 DEPENDPATH  += $$PWD/qtlib/src
 
+mac: LIBS+= -Wl,-dead_strip
+mac: LIBS+= -Wl,-dead_strip_dylibs
+mac: LIBS+= -Wl,-bind_at_load
 
 win32: RC_ICONS = res/icon.ico
 ICON = res/logo.icns


### PR DESCRIPTION
Before:
```
% wc -c zecpaperwalletui.app/Contents/MacOS/zecpaperwalletui 
 8976648 zecpaperwalletui.app/Contents/MacOS/zecpaperwalletui
```
After:
```
% wc -c zecpaperwalletui.app/Contents/MacOS/zecpaperwalletui 
 2156384 zecpaperwalletui.app/Contents/MacOS/zecpaperwalletui
```

Before:
```
% otool -L zecpaperwalletui.app/Contents/MacOS/zecpaperwalletui 
zecpaperwalletui.app/Contents/MacOS/zecpaperwalletui:
	/System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 59306.41.2)
	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 1673.126.0)
	/opt/local/libexec/qt5/lib/QtWidgets.framework/Versions/5/QtWidgets (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtGui.framework/Versions/5/QtGui (compatibility version 5.14.0, current version 5.14.0)
	/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit (compatibility version 45.0.0, current version 1894.10.126)
	/System/Library/Frameworks/Metal.framework/Versions/A/Metal (compatibility version 1.0.0, current version 212.2.3)
	/opt/local/libexec/qt5/lib/QtCore.framework/Versions/5/QtCore (compatibility version 5.14.0, current version 5.14.0)
	/System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit (compatibility version 1.0.0, current version 275.0.0)
	/System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/AGL.framework/Versions/A/AGL (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 800.7.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
```
After:
```
% otool -L zecpaperwalletui.app/Contents/MacOS/zecpaperwalletui 
zecpaperwalletui.app/Contents/MacOS/zecpaperwalletui:
	/System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 59306.41.2)
	/opt/local/libexec/qt5/lib/QtWidgets.framework/Versions/5/QtWidgets (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtGui.framework/Versions/5/QtGui (compatibility version 5.14.0, current version 5.14.0)
	/opt/local/libexec/qt5/lib/QtCore.framework/Versions/5/QtCore (compatibility version 5.14.0, current version 5.14.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 800.7.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
```

Before:
```
Load command 4
            cmd LC_DYLD_INFO_ONLY
        cmdsize 48
     rebase_off 6352896
    rebase_size 4704
       bind_off 6357600
      bind_size 5576
  weak_bind_off 6363176
 weak_bind_size 712
  lazy_bind_off 6363888
 lazy_bind_size 12216
     export_off 6376104
    export_size 328824
```
After:
```
Load command 4
            cmd LC_DYLD_INFO_ONLY
        cmdsize 48
     rebase_off 1769472
    rebase_size 1248
       bind_off 1770720
      bind_size 12544
  weak_bind_off 1783264
 weak_bind_size 336
  lazy_bind_off 0
 lazy_bind_size 0
     export_off 1783600
    export_size 41864
```